### PR TITLE
Fix table truncation logic

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -498,9 +498,13 @@ var _ lipglosstable.Data = tableData{}
 
 func (t tableData) At(row, col int) string {
 	data := t.m.rows[t.m.start+row][col]
-	data = ansi.Truncate(data, t.maxColumnWidths[col], "…")
-	padding := strings.Repeat(" ", max(0, t.maxColumnWidths[col]-lipgloss.Width(data)))
-	return data + padding
+	lines := strings.Split(data, "\n")
+	for i, line := range lines {
+		line = ansi.Truncate(line, t.maxColumnWidths[col], "…")
+		padding := strings.Repeat(" ", max(0, t.maxColumnWidths[col]-lipgloss.Width(line)))
+		lines[i] = line + padding
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (t tableData) Rows() int {

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -160,6 +161,34 @@ func TestTableAlignment(t *testing.T) {
 		got := ansi.Strip(baseStyle.Render(biscuits.View()))
 		golden.RequireEqual(t, []byte(got))
 	})
+}
+
+func TestMultiLineCellNotTruncated(t *testing.T) {
+	columns := []Column{
+		{Title: "Index"},
+		{Title: "Summary"},
+	}
+	multiLineSummary := "Main commit subject\n- Fix review issues\n- Use domain types"
+	rows := []Row{
+		{"1", multiLineSummary},
+	}
+	model := New(
+		WithColumns(columns),
+		WithRows(rows),
+		WithFocused(true),
+	)
+	maxColumnWidths := model.getMaxColumnWidths()
+	td := tableData{m: model, maxColumnWidths: maxColumnWidths}
+	got := td.At(0, 1)
+	for i, line := range strings.Split(multiLineSummary, "\n") {
+		if !strings.Contains(got, strings.TrimSpace(line)) {
+			t.Errorf("line %d missing from output: %q\ngot: %q", i, line, got)
+		}
+	}
+	gotLines := strings.Split(got, "\n")
+	if len(gotLines) != 3 {
+		t.Errorf("expected 3 lines, got %d: %q", len(gotLines), got)
+	}
 }
 
 func TestWrapCursor(t *testing.T) {


### PR DESCRIPTION


<!-- 

#### Testing

<img src="XXXCOPYURLXXX" alt="" width="300"/> 

<video src="XXXCOPYURLXXX" alt="" width="300"/>

| Before | After |
| ------------- | ------------- |
| <img src="XXXCOPYURLXXX" alt="" width="300"/> | <img src="XXXCOPYURLXXX" alt="" width="300"/> |


| Before | After |
| ------------- | ------------- |
| <video src="XXXCOPYURLXXX" alt="" width="300"/> | <video src="XXXCOPYURLXXX" alt="" width="300"/> |

<details>
  <summary>Detailed Section (click me)</summary>
  
</details>

-->

#### Ticket: [](https://jira.tinyspeck.com/browse/)

#### Feature flag(s): ``
